### PR TITLE
Fix typo in ConvertPixel64RGBX16ToPixel48RGB16()

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -704,7 +704,7 @@ uint8_t * DETEX_RESTRICT target_pixel_buffer) {
 static void ConvertPixel64RGBX16ToPixel48RGB16(uint8_t * DETEX_RESTRICT source_pixel_buffer, int nu_pixels,
 uint8_t * DETEX_RESTRICT target_pixel_buffer) {
 	uint64_t *source_pixel64_buffer = (uint64_t *)source_pixel_buffer;
-	uint16_t *target_pixel16_buffer = (uint16_t *)target_pixel16_buffer;
+	uint16_t *target_pixel16_buffer = (uint16_t *)target_pixel_buffer;
 	for (int i = 0; i < nu_pixels; i++) {
 		uint64_t pixel = *source_pixel64_buffer;
 		target_pixel16_buffer[0] = detexPixel64GetR16(pixel);


### PR DESCRIPTION
The variable `target_pixel16_buffer` was being initialized to itself (while also being uninitialized), which is probably not what we want (and undefined behaviour). The function only makes sense if it's initialized to the address of the `target_pixel_buffer` argument instead.