### PR TITLE
Add #pragma once to all header files

### DIFF
--- a/bits.h
+++ b/bits.h
@@ -18,6 +18,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 /* Data structure used to extract bits from 128-bit bitstring. */
 
+#pragma once
+
 typedef struct {
 	uint64_t data0;
 	uint64_t data1;

--- a/bptc-tables.h
+++ b/bptc-tables.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 extern const uint8_t detex_bptc_table_P2[64 * 16];
 extern const uint8_t detex_bptc_table_P3[64 * 16];
 

--- a/detex-png.h
+++ b/detex-png.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/file-info.h
+++ b/file-info.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 typedef struct {
 	uint32_t texture_format;
 	int ktx_support;

--- a/half-float.h
+++ b/half-float.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 void detexConvertHalfFloatToFloat(uint16_t *source_buffer, int n, float *target_buffer);
 
 void detexConvertFloatToHalfFloat(float *source_buffer, int n, uint16_t *target_buffer);

--- a/hdr.h
+++ b/hdr.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 void detexConvertHDRHalfFloatToUInt16(uint16_t *buffer, int n);
 
 void detexConvertHDRFloatToFloat(float *buffer, int n);

--- a/misc.h
+++ b/misc.h
@@ -16,6 +16,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
+#pragma once
+
 
 void detexSetErrorMessage(const char *format, ...);
 


### PR DESCRIPTION
I'm trying to use detex as an inline-included library (i.e. by #including source `.c` files into a translation unit of my own) to circumvent library building issues. I've encountered a problem where `bits.h` would be included from several files, causing an error of redefinition of the struct and the functions in it.

This is a simple and non-invasive change that fixes it. `#pragma once` is functionally equivalent to header guards and has [wide support from compilers](https://en.wikipedia.org/wiki/Pragma_once#Portability) all across the board. It does not impact any other aspect of the project.