### PR TITLE
Fix misc.c for compilation with MSVC

### DIFF
--- a/detex.h
+++ b/detex.h
@@ -72,7 +72,11 @@ __BEGIN_DECLS
 #include <stdint.h>
 #include <stdbool.h>
 
+#if _MSC_VER
+#define DETEX_INLINE_ONLY __forceinline
+#else
 #define DETEX_INLINE_ONLY __attribute__((always_inline)) inline
+#endif
 #define DETEX_RESTRICT __restrict
 
 /* Maximum uncompressed block size in bytes. */

--- a/file-info.c
+++ b/file-info.c
@@ -19,11 +19,20 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#if !_MSC_VER
 #include <strings.h>
+#endif
 
 #include "detex.h"
 #include "file-info.h"
 #include "misc.h"
+
+#if _MSC_VER
+static DETEX_INLINE_ONLY int strcasecmp(const char *s1, const char *s2)
+{
+	return _stricmp(s1, s2);
+}
+#endif
 
 /*
 	The TextureInfo structure has the following fields:

--- a/misc.c
+++ b/misc.c
@@ -20,10 +20,32 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#if !_MSC_VER
 #include <strings.h>
+#endif
 #include <stdarg.h>
 
 #include "detex.h"
+
+#if _MSC_VER
+// Implementations of the additional POSIX string functions from strings.h, which do not appear in MSVC.
+int vasprintf(char ** DETEX_RESTRICT ret, const char * DETEX_RESTRICT format, va_list ap) {
+	int len = _vsnprintf(NULL, 0, format, ap);
+	if (len < 0)
+		return -1;
+	*ret = (char*)malloc(len + 1);
+	if (!*ret)
+		return -1;
+	_vsnprintf(*ret, len + 1, format, ap);
+	(*ret)[len] = 0;
+	return len;
+}
+
+static DETEX_INLINE_ONLY int strncasecmp(const char *s1, const char *s2, size_t n)
+{
+	return _strnicmp(s1, s2, n);
+}
+#endif
 
 // Generate bit mask from bit0 to bit1 (inclusive).
 static DETEX_INLINE_ONLY uint64_t GenerateMask(int bit0, int bit1) {


### PR DESCRIPTION
Microsoft's CRT does not provide the POSIX `strings.h` header, so this change reimplements the two functions from it that are used by detex for MSVC. I've tried to make the change as noninvasive as possible, no other aspects of the project are affected.