### PR TITLE
fix an error in compression

### DIFF
--- a/bits.h
+++ b/bits.h
@@ -28,7 +28,7 @@ uint32_t detexBlock128ExtractBits(detexBlock128 *block, int nu_bits);
 
 /* Return bitfield from bit0 to bit1 from 64-bit bitstring. */
 static DETEX_INLINE_ONLY uint32_t detexGetBits64(uint64_t data, int bit0, int bit1) {
-	return (data & (((uint64_t)1 << (bit1 + 1)) - 1)) >> bit0;
+	return (data >> bit0) & ((((uint64_t)1u) << (bit1 - bit0 + 1)) - 1);
 }
 
 /* Return reversed bitfield (bit1 to bit0) from 64-bit bitstring. */


### PR DESCRIPTION
- we can't safely shift more than on 63 bits for uint64_t
- changed an order in bitwise operations for extracting bits